### PR TITLE
root object as contract

### DIFF
--- a/src/LogoFX.Client.Bootstrapping.Platform.NET.Tests/LogoFX.Client.Bootstrapping.Platform.NET.Tests.csproj
+++ b/src/LogoFX.Client.Bootstrapping.Platform.NET.Tests/LogoFX.Client.Bootstrapping.Platform.NET.Tests.csproj
@@ -80,7 +80,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions">
-      <Version>5.10.2</Version>
+      <Version>5.10.3</Version>
     </PackageReference>
     <PackageReference Include="LogoFX.Client.Bootstrapping.Adapters.SimpleContainer">
       <Version>2.1.0</Version>

--- a/src/LogoFX.Client.Bootstrapping.Platform/android/Resources/Resource.Designer.cs
+++ b/src/LogoFX.Client.Bootstrapping.Platform/android/Resources/Resource.Designer.cs
@@ -15,7 +15,7 @@ namespace LogoFX.Client.Bootstrapping
 {
 	
 	
-	[System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
 	public partial class Resource
 	{
 		

--- a/src/LogoFX.Client.Bootstrapping.Platform/src/BootstrapperContainerBase.Middleware.cs
+++ b/src/LogoFX.Client.Bootstrapping.Platform/src/BootstrapperContainerBase.Middleware.cs
@@ -167,19 +167,25 @@ public class RegisterPlatformSpecificMiddleware :
 #endif
             <TIocContainerAdapter>>
         where TIocContainerAdapter : class, IIocContainer, IIocContainerAdapter, IBootstrapperAdapter         
-    {
+    {        
         private readonly Type _rootObjectType;
         private readonly bool _displayView;
+        private readonly bool _registerRoot;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CreateRootObjectMiddleware{TIocContainerAdapter}"/> class.
-        /// </summary>
+        /// </summary>        
         /// <param name="rootObjectType">Type of the root object.</param>
         /// <param name="displayView">if set to <c>true</c> the root view is displayed.</param>
-        public CreateRootObjectMiddleware(Type rootObjectType, bool displayView)
-        {
+        /// <param name="registerRoot">if set to <c>true</c> the root is registered.</param>
+        public CreateRootObjectMiddleware(            
+            Type rootObjectType,
+            bool displayView, 
+            bool registerRoot)
+        {           
             _rootObjectType = rootObjectType;
             _displayView = displayView;
+            _registerRoot = registerRoot;
         }
 
         /// <summary>
@@ -201,7 +207,11 @@ public class RegisterPlatformSpecificMiddleware :
 #endif
             <TIocContainerAdapter> @object)
         {
-            @object.Registrator.RegisterSingleton(_rootObjectType, _rootObjectType);
+            if (_registerRoot)
+            {
+                @object.Registrator.RegisterSingleton(_rootObjectType, _rootObjectType);
+            }
+            
             EventHandler strongHandler = ObjectOnInitializationCompleted;
             @object.InitializationCompleted += WeakDelegate.From(strongHandler);
             return @object;

--- a/src/LogoFX.Client.Bootstrapping.Platform/src/BootstrapperContainerBase.cs
+++ b/src/LogoFX.Client.Bootstrapping.Platform/src/BootstrapperContainerBase.cs
@@ -505,9 +505,16 @@ namespace LogoFX.Client.Bootstrapping
 #endif
                             <TIocContainerAdapter>>
                     ())                    
-                    .UseBootstrapperComposition().
-                    Use(new RegisterViewModelsMiddleware(creationOptions.ExcludedTypes))
+                    .UseBootstrapperComposition()                    
                     .Use(new RegisterPlatformSpecificMiddleware());
+                if (creationOptions.RegisterViewModels)
+                {
+                    Use(new RegisterViewModelsMiddleware(creationOptions.ExcludedTypes));
+                }
+                if (creationOptions.RegisterViewModelsAsContracts)
+                {
+                    Use(new RegisterViewModelsAsContractsMiddleware(creationOptions.ExcludedTypes));
+                }
             }                      
         }        
 

--- a/src/LogoFX.Client.Bootstrapping.Platform/src/BootstrapperContainerBase.cs
+++ b/src/LogoFX.Client.Bootstrapping.Platform/src/BootstrapperContainerBase.cs
@@ -92,8 +92,10 @@ namespace LogoFX.Client.Bootstrapping
             Func<TIocContainer, TIocContainerAdapter> adapterCreator,
                 BootstrapperCreationOptions creationOptions) : base(iocContainer, adapterCreator, AddRootObject(creationOptions))
             {
-                Use(new CreateRootObjectMiddleware<TIocContainerAdapter>(typeof(TRootObject),
-                    creationOptions.DisplayRootView));
+                Use(new CreateRootObjectMiddleware<TIocContainerAdapter>(                    
+                    typeof(TRootObject),
+                    creationOptions.DisplayRootView,
+                    true));
             }
 
             private static BootstrapperCreationOptions AddRootObject(BootstrapperCreationOptions creationOptions)
@@ -109,6 +111,80 @@ namespace LogoFX.Client.Bootstrapping
                 return creationOptions;
             }
         }
+
+        /// <summary>
+        /// Application bootstrapper with ioc container, its adapter and root object.
+        /// </summary>        
+        /// <typeparam name="TRootObject"></typeparam>
+        public new class WithRootObjectAsContract<TRootObject> :
+#if TEST
+    TestBootstrapperContainerBase
+#else
+    BootstrapperContainerBase
+#endif
+            <TIocContainerAdapter, TIocContainer>
+        {
+#if TEST
+            /// <summary>
+            /// Initializes a new instance of <see cref="TestBootstrapperContainerBase{TIocContainerAdapter, TIocContainer}.WithRootObject{TRootObject}"/>
+            /// </summary>
+            /// <param name="iocContainer">The ioc container.</param>
+            /// <param name="adapterCreator">The adapter creation function.</param>
+#else
+            /// <summary>
+            /// Initializes a new instance of <see cref="BootstrapperContainerBase{TIocContainerAdapter, TIocContainer}.WithRootObject{TRootObject}"/>
+            /// </summary>
+            /// <param name="iocContainer">The ioc container.</param>
+            /// <param name="adapterCreator">The adapter creation function.</param>
+#endif
+            public WithRootObjectAsContract(TIocContainer iocContainer,
+            Func<TIocContainer, TIocContainerAdapter> adapterCreator)
+                : this(iocContainer, adapterCreator, new BootstrapperCreationOptions
+                {
+                    ExcludedTypes = new List<Type> { typeof(TRootObject) }
+                })
+            {
+            }
+
+#if TEST
+            /// <summary>
+            /// Initializes a new instance of <see cref="TestBootstrapperContainerBase{TIocContainerAdapter, TIocContainer}.WithRootObject{TRootObject}"/>
+            /// </summary>
+            /// <param name="iocContainer">The ioc container.</param>
+            /// <param name="adapterCreator">The adapter creation function.</param>
+            /// <param name="creationOptions">The bootstrapper creation options.</param>
+#else
+            /// <summary>
+            /// Initializes a new instance of <see cref="BootstrapperContainerBase{TIocContainerAdapter, TIocContainer}.WithRootObject{TRootObject}"/>
+            /// </summary>
+            /// <param name="iocContainer">The ioc container.</param>
+            /// <param name="adapterCreator">The adapter creation function.</param>
+            /// <param name="creationOptions">The bootstrapper creation options.</param>
+#endif
+            public WithRootObjectAsContract(TIocContainer iocContainer,
+            Func<TIocContainer, TIocContainerAdapter> adapterCreator,
+                BootstrapperCreationOptions creationOptions) : base(iocContainer, adapterCreator, AddRootObject(creationOptions))
+            {
+                Use(new CreateRootObjectMiddleware<TIocContainerAdapter>(                    
+                    typeof(TRootObject),
+                    creationOptions.DisplayRootView, 
+                    false));
+            }
+
+            private static BootstrapperCreationOptions AddRootObject(BootstrapperCreationOptions creationOptions)
+            {
+                if (creationOptions.ExcludedTypes == null)
+                {
+                    creationOptions.ExcludedTypes = new List<Type>();
+                }               
+                if (creationOptions.ExcludedTypes.Contains(typeof(TRootObject)) == false)
+                {
+                    creationOptions.ExcludedTypes.Add(typeof(TRootObject));
+                }
+                return creationOptions;
+            }
+        }
+
 #if TEST
         /// <summary>
         /// Initializes a new instance of the 
@@ -272,8 +348,10 @@ namespace LogoFX.Client.Bootstrapping
                 BootstrapperCreationOptions creationOptions) :
                 base(iocContainerAdapter, AddRootObject(creationOptions))
             {
-                Use(new CreateRootObjectMiddleware<TIocContainerAdapter>(typeof (TRootObject),
-                    creationOptions.DisplayRootView));
+                Use(new CreateRootObjectMiddleware<TIocContainerAdapter>(                    
+                    typeof(TRootObject),
+                    creationOptions.DisplayRootView,
+                    true));
             }
 
             private static BootstrapperCreationOptions AddRootObject(BootstrapperCreationOptions creationOptions)
@@ -283,6 +361,74 @@ namespace LogoFX.Client.Bootstrapping
                     creationOptions.ExcludedTypes = new List<Type>();
                 }
                 if (creationOptions.ExcludedTypes.Contains(typeof (TRootObject)) == false)
+                {
+                    creationOptions.ExcludedTypes.Add(typeof(TRootObject));
+                }
+                return creationOptions;
+            }
+        }
+
+        /// <summary>
+        /// Application bootstrapper with ioc container adapter and root object.
+        /// </summary>        
+        /// <typeparam name="TRootObject"></typeparam>
+        public class WithRootObjectAsContract<TRootObject> :
+#if TEST
+    TestBootstrapperContainerBase
+#else
+    BootstrapperContainerBase
+#endif
+            <TIocContainerAdapter>
+        {
+#if TEST
+            /// <summary>
+            /// Initializes a new instance of <see cref="TestBootstrapperContainerBase{TIocContainerAdapter}.WithRootObject{TRootObject}"/>
+            /// </summary>
+            /// <param name="iocContainerAdapter">The ioc container adapter</param>
+#else
+            /// <summary>
+            /// Initializes a new instance of <see cref="BootstrapperContainerBase{TIocContainerAdapter}.WithRootObject{TRootObject}"/>
+            /// </summary>
+            /// <param name="iocContainerAdapter">The ioc container adapter.</param>
+#endif
+            public WithRootObjectAsContract(TIocContainerAdapter iocContainerAdapter)
+                : this(iocContainerAdapter, new BootstrapperCreationOptions
+                {
+                    ExcludedTypes = new List<Type> {                         
+                        typeof(TRootObject) }
+                })
+            {
+            }
+#if TEST
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TestBootstrapperContainerBase{TIocContainerAdapter}.WithRootObject{TRootObject}"/> class.
+            /// </summary>
+            /// <param name="iocContainerAdapter">The ioc container adapter.</param>
+            /// <param name="creationOptions">The creation options.</param>
+#else
+            /// <summary>
+            /// Initializes a new instance of the <see cref="BootstrapperContainerBase{TIocContainerAdapter}.WithRootObject{TRootObject}"/> class.
+            /// </summary>
+            /// <param name="iocContainerAdapter">The ioc container adapter.</param>
+            /// <param name="creationOptions">The creation options.</param>
+#endif
+            public WithRootObjectAsContract(TIocContainerAdapter iocContainerAdapter,
+                BootstrapperCreationOptions creationOptions) :
+                base(iocContainerAdapter, AddRootObject(creationOptions))
+            {
+                Use(new CreateRootObjectMiddleware<TIocContainerAdapter>(
+                    typeof(TRootObject),
+                    creationOptions.DisplayRootView,
+                    false));
+            }
+
+            private static BootstrapperCreationOptions AddRootObject(BootstrapperCreationOptions creationOptions)
+            {
+                if (creationOptions.ExcludedTypes == null)
+                {
+                    creationOptions.ExcludedTypes = new List<Type>();
+                }               
+                if (creationOptions.ExcludedTypes.Contains(typeof(TRootObject)) == false)
                 {
                     creationOptions.ExcludedTypes.Add(typeof(TRootObject));
                 }

--- a/src/LogoFX.Client.Bootstrapping.Platform/src/BootstrapperExtensions.cs
+++ b/src/LogoFX.Client.Bootstrapping.Platform/src/BootstrapperExtensions.cs
@@ -16,6 +16,7 @@ namespace LogoFX.Client.Bootstrapping
         /// <param name="bootstrapper">The bootstrapper.</param>
         /// <param name="rootObjectType">The type of the root object.</param>
         /// <param name="displayView">if set to <c>true</c> view is displayed.</param>
+        /// <param name="registerRoot">if set to <c>true</c> root is registered.</param>
         public static
 #if TEST
     TestBootstrapperContainerBase
@@ -30,10 +31,43 @@ namespace LogoFX.Client.Bootstrapping
     BootstrapperContainerBase
 #endif
             <TIocContainerAdapter> bootstrapper,
-            Type rootObjectType, bool displayView) 
+            Type rootObjectType, 
+            bool displayView,
+            bool registerRoot) 
             where TIocContainerAdapter : class, IIocContainer, IIocContainerAdapter, IBootstrapperAdapter
         {
-            bootstrapper.Use(new CreateRootObjectMiddleware<TIocContainerAdapter>(rootObjectType, displayView));
+            bootstrapper.Use(new CreateRootObjectMiddleware<TIocContainerAdapter>(rootObjectType, displayView, registerRoot));
+            return bootstrapper;
+        }
+
+        /// <summary>
+        /// Uses the root object creation middleware.
+        /// </summary>
+        /// <typeparam name="TIocContainerAdapter">The type of the ioc container adapter.</typeparam>
+        /// <param name="bootstrapper">The bootstrapper.</param>        
+        /// <param name="rootObjectType">The type of the root object.</param>
+        /// <param name="displayView">if set to <c>true</c> view is displayed.</param>
+        /// <param name="registerRoot">if set to <c>true</c> root is registered.</param>
+        public static
+#if TEST
+            TestBootstrapperContainerBase
+#else
+    BootstrapperContainerBase
+#endif
+            <TIocContainerAdapter>
+            UseRootObjectAsContract<TIocContainerAdapter>(this
+#if TEST
+                    TestBootstrapperContainerBase
+#else
+    BootstrapperContainerBase
+#endif
+                    <TIocContainerAdapter> bootstrapper,               
+                Type rootObjectType, 
+                bool displayView,
+                bool registerRoot)
+            where TIocContainerAdapter : class, IIocContainer, IIocContainerAdapter, IBootstrapperAdapter
+        {
+            bootstrapper.Use(new CreateRootObjectMiddleware<TIocContainerAdapter>(rootObjectType, displayView, registerRoot));
             return bootstrapper;
         }
 

--- a/src/LogoFX.Client.Bootstrapping.Platform/uwp/LogoFX.Client.Bootstrapping.Platform.UWP.csproj
+++ b/src/LogoFX.Client.Bootstrapping.Platform/uwp/LogoFX.Client.Bootstrapping.Platform.UWP.csproj
@@ -156,7 +156,7 @@
       <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.9</Version>
+      <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Solid.Common">
       <Version>2.2.0</Version>

--- a/src/LogoFX.Client.Bootstrapping.Xamarin.Forms/LogoFX.Client.Bootstrapping.Xamarin.Forms.csproj
+++ b/src/LogoFX.Client.Bootstrapping.Xamarin.Forms/LogoFX.Client.Bootstrapping.Xamarin.Forms.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Solid.Practices.IoC" Version="2.2.0" />
     <PackageReference Include="Solid.Practices.Middleware" Version="2.2.0" />
     <PackageReference Include="Solid.Practices.Modularity" Version="2.2.0" />
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.0.396" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LogoFX.Client.Bootstrapping/BootstrapperCreationOptions.cs
+++ b/src/LogoFX.Client.Bootstrapping/BootstrapperCreationOptions.cs
@@ -19,6 +19,9 @@ namespace LogoFX.Client.Bootstrapping
             DiscoverAssemblies = true;
             UseDefaultMiddlewares = true;
             DisplayRootView = true;
+            RegisterRoot = true;
+            RegisterViewModels = true;
+            RegisterViewModelsAsContracts = false;
             ExcludedTypes = new List<Type>();
         }
 
@@ -86,5 +89,32 @@ namespace LogoFX.Client.Bootstrapping
         /// The type of the root object.
         /// </value>
         public List<Type> ExcludedTypes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the root object is registered
+        /// into the ioc container. This value is used only when there is a root object.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the root object is registered; otherwise, <c>false</c>.
+        /// </value>
+        public bool RegisterRoot { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the view models are registered
+        /// automagically into the ioc container.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the view models are registered; otherwise, <c>false</c>.
+        /// </value>
+        public bool RegisterViewModels { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the view models are registered
+        /// automagically into the ioc container as contracts.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the view models are registered as contracts; otherwise, <c>false</c>.
+        /// </value>
+        public bool RegisterViewModelsAsContracts { get; set; }
     }
 }

--- a/src/LogoFX.Client.Bootstrapping/Middleware.cs
+++ b/src/LogoFX.Client.Bootstrapping/Middleware.cs
@@ -67,4 +67,65 @@ namespace LogoFX.Client.Bootstrapping
             return @object;
         }
     }
+
+    /// <summary>
+    /// Registers automagically the application's view models in the transient lifestyle.
+    /// </summary>
+    public class RegisterViewModelsAsContractsMiddleware :
+        IMiddleware<IBootstrapperWithRegistrator>
+    {
+        private readonly IEnumerable<Type> _excludedTypes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegisterViewModelsMiddleware"/> class.
+        /// </summary>
+        /// <param name="excludedTypes">The type of the root object.</param>
+        public RegisterViewModelsAsContractsMiddleware(IEnumerable<Type> excludedTypes)
+        {
+            _excludedTypes = excludedTypes;
+        }
+
+        /// <summary>
+        /// Applies the middleware on the specified object.
+        /// </summary>
+        /// <param name="object">The object.</param>
+        /// <returns></returns>
+        public IBootstrapperWithRegistrator Apply(
+            IBootstrapperWithRegistrator @object)
+        {
+            var internalMiddleware = new RegisterViewModelsAsContractsMiddleware<IBootstrapperWithRegistrator>(_excludedTypes);
+            return internalMiddleware.Apply(@object);
+        }
+    }
+
+    /// <summary>
+    /// Registers automagically the application's view models as contracts in the transient lifestyle.
+    /// </summary>
+    public class RegisterViewModelsAsContractsMiddleware<TBootstrapper> :
+        IMiddleware<TBootstrapper>
+        where TBootstrapper : class, IHaveRegistrator, IAssemblySourceProvider
+    {
+        private readonly IEnumerable<Type> _excludedTypes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegisterViewModelsMiddleware"/> class.
+        /// </summary>
+        /// <param name="excludedTypes">The type of the root object.</param>
+        public RegisterViewModelsAsContractsMiddleware(IEnumerable<Type> excludedTypes)
+        {
+            _excludedTypes = excludedTypes;
+        }
+
+        /// <summary>
+        /// Applies the middleware on the specified object.
+        /// </summary>
+        /// <param name="object">The object.</param>
+        /// <returns></returns>
+        public TBootstrapper Apply(
+            TBootstrapper @object)
+        {
+            @object.Registrator.RegisterViewModelsAsContracts(@object.Assemblies, _excludedTypes);
+            return @object;
+        }
+    }
 }


### PR DESCRIPTION
Added option for registering root object by its contract - this requires registering the implementation elsewhere